### PR TITLE
classlib: removed unnecessary print

### DIFF
--- a/classlib.lua
+++ b/classlib.lua
@@ -225,7 +225,6 @@ function instanceof(self, class, direct)
 	local check = false
 	-- Check if any of 'self's base classes is inheriting from 'class'
 	for k, v in pairs(superMultiple(self)) do
-		print(v)
 		check = instanceof(v, class, false)
 		if check then
 			break


### PR DESCRIPTION
There was one print statement remaining in the instanceof function that was probably added for development purposes. Since this doesn't serve any purpose I think it's fair to say that it should be removed.